### PR TITLE
ENH: Remove HTML and Liquid comments from `index.md`

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,9 +5,6 @@ permalink: index.html  # Is the only page that doesn't follow the pattern /:path
 ---
 FIXME: Add information about fMRI analysis in Neuroimaging
 
-<!-- this is an html comment -->
-
-{% comment %} This is a comment in Liquid {% endcomment %}
 
 > ## Prerequisites
 >


### PR DESCRIPTION
Remove HTML and Liquid comments from `index.md`.

The Liquid comment is visible in the new Workbench infrastructure index page. None of these comments are necessary, and were present since the very first commit (8f66f41), as they were present in the default contents of the `index.md` file in the legacy Carpentries infrastructure files.